### PR TITLE
Comment out Nominatim code as it was far exceeding rate limits

### DIFF
--- a/app/LinkedArt/Place.php
+++ b/app/LinkedArt/Place.php
@@ -21,7 +21,7 @@ class Place
                 'application/ld+json'
             ],
             'approximated_by' => [
-                self::createPoint($data['summary_title'])
+                //self::createPoint($data['summary_title'])
             ],
             'subject_of' => [
                 [


### PR DESCRIPTION
The site was far exceeding the Nominatim usage policy, so these requests were being denied. We've disabled this functionality for now as, as far as we can tell, it doesn't seem to be being used anywhere important (and in any case it's not working at present).

See:

https://operations.osmfoundation.org/policies/nominatim/